### PR TITLE
Don't suppress HTTP errors

### DIFF
--- a/src/Suggester/NdeTerms/NdeTermsSuggest.php
+++ b/src/Suggester/NdeTerms/NdeTermsSuggest.php
@@ -82,7 +82,7 @@ class NdeTermsSuggest implements SuggesterInterface
     private function graphqlExecute(string $endpoint, string $agent, string $query): array
     {
         $headers = ['Content-Type: application/json', "User-Agent: $agent"];
-        $data = @file_get_contents($endpoint, false, stream_context_create([
+        $data = file_get_contents($endpoint, false, stream_context_create([
             'http' => [
                 'method' => 'POST',
                 'header' => $headers,


### PR DESCRIPTION
In my case I had misconfigured the SSL truststore, causing the
requests to termennetwerk-api.netwerkdigitaalerfgoed.nl to fail
silently. With this change the error message is exposed in that
case.