### PR TITLE
Add NDE Art & Architecture Thesaurus

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,7 @@ This module includes the following vocabularies:
 ### [Dutch Digital Heritage Network of Terms: NDE Termennetwerk](https://termennetwerk.netwerkdigitaalerfgoed.nl/)
 
 - Archeologisch Basisregister
+- Art & Architecture Thesaurus (AAT, Dutch localization)
 - Brinkman trefwoordenthesaurus
 - Cultuurhistorische Thesaurus
 - GTAA: genres

--- a/config/module.config.php
+++ b/config/module.config.php
@@ -80,6 +80,7 @@ return [
             // @todo Add more LC data types
             
             /* Network of Terms of the Dutch National Network for Digital Heritage */
+            'valuesuggest:ndeterms:aat' => \ValueSuggest\Service\NdeTermsDataTypeFactory::class,
             'valuesuggest:ndeterms:abr' => \ValueSuggest\Service\NdeTermsDataTypeFactory::class,
             'valuesuggest:ndeterms:btt' => \ValueSuggest\Service\NdeTermsDataTypeFactory::class,
             'valuesuggest:ndeterms:cht' => \ValueSuggest\Service\NdeTermsDataTypeFactory::class,

--- a/src/Service/NdeTermsDataTypeFactory.php
+++ b/src/Service/NdeTermsDataTypeFactory.php
@@ -16,6 +16,10 @@ class NdeTermsDataTypeFactory implements FactoryInterface
             'label' => 'NDE: Archeologisch Basisregister', // @translate
             'source' => 'https://data.cultureelerfgoed.nl/PoolParty/sparql/term/id/abr',
         ],
+        'valuesuggest:ndeterms:aat' => [
+            'label' => 'NDE: Art & Architecture Thesaurus', // @translate
+            'source' => 'http://vocab.getty.edu/aat/sparql',
+        ],
         'valuesuggest:ndeterms:btt' => [
             'label' => 'NDE: Brinkman trefwoordenthesaurus', // @translate
             'source' => 'http://data.bibliotheken.nl/thes/brinkman/sparql',


### PR DESCRIPTION
The AAT was already included, but the NDE exposes the Dutch localization
of this thesaurus.