### PR TITLE
Use 'OPTIMIZED' query mode

### DIFF
--- a/src/Suggester/NdeTerms/NdeTermsSuggest.php
+++ b/src/Suggester/NdeTerms/NdeTermsSuggest.php
@@ -52,7 +52,8 @@ class NdeTermsSuggest implements SuggesterInterface
         return "query FindTerm {
         terms(
             sources: [\"$source\"],
-            query: \"$searchphrase\")
+            query: \"$searchphrase\",
+            queryMode: OPTIMIZED)
         {
             source {
                 name


### PR DESCRIPTION
As introduced in
https://github.com/netwerk-digitaal-erfgoed/network-of-terms-api/pull/398

In particular this makes searching for words with
diacritical marks in Virtuoso-backed sources such
as the RKD work